### PR TITLE
18: fix for FluentValidation errors when importing exported CSV to the same catalog

### DIFF
--- a/VirtoCommerce.CatalogCsvImportModule.Data/Model/CsvProduct.cs
+++ b/VirtoCommerce.CatalogCsvImportModule.Data/Model/CsvProduct.cs
@@ -240,8 +240,11 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Model
                 if (Category == null)
                     return null;
 
+                if (!string.IsNullOrEmpty(Category.Path))
+                    return Category.Path;
+
                 var parents = Category.Parents ?? new Category[] { };
-                return string.Join("/", parents.Select(x => x.Path).Concat(new[] { Category.Path }));
+                return string.Join("/", parents.Select(x => x.Name).Concat(new[] { Category.Name }));
             }
             set
             {


### PR DESCRIPTION
This PR fixes an error described in #18. The error had been caused by invalid values of the `CategoryPath` field in exported file:
* The CSV import module uses `Category.Path` property to [build `CategoryPath` value](https://github.com/VirtoCommerce/vc-module-catalog-csv-import/blob/master/VirtoCommerce.CatalogCsvImportModule.Data/Model/CsvProduct.cs#L243). But it looks like the catalog module does not fill this property for categories, so it is `null` for all categories during the export. So, for example, products from category `Dresses > Day dresses > High neck dresses` have `CategoryPath` value like `//` instead of `Dresses/Day dresses/High neck dresses`. When importing a CSV with such paths, import code attempted to create a `Category` with empty name and failed.
* But even when the `Category.Path` is filled correctly, concatenating `Category.Path` values to build `CategoryPath` for products doesn't seem right. For the aforementioned example categories have `Path` values like `Dresses`, `Dresses/Day dresses` and `Dresses/Day dresses/High neck dresses`, so the export code will produce `CategoryPath` value like `/Dresses/Dresses/Day dresses/Dresses/Day dresses/High neck dresses` with lots of duplicated segments. I think it should concatenate `Category.Name`s instead - this way it will match the [category import code](https://github.com/VirtoCommerce/vc-module-catalog-csv-import/blob/master/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs#L275) behavior.