### PR TITLE
VP-2519 Allow import SEO properties for item variations

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvSeoInfo.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvSeoInfo.cs
@@ -1,4 +1,4 @@
-﻿using VirtoCommerce.CoreModule.Core.Seo;
+using VirtoCommerce.CoreModule.Core.Seo;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
@@ -10,7 +10,10 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
             SemanticUrl = source.SemanticUrl;
             LanguageCode = source.LanguageCode;
             StoreId = source.StoreId;
-
+            ObjectId = source.ObjectId;
+            ObjectType = source.ObjectType;
+            Id = source.Id;
+            
             if (PageTitle.IsNullOrEmpty())
             {
                 PageTitle = source.PageTitle;


### PR DESCRIPTION
### Problem
SeoInfo can't  be imported for variations

### Solution
add fields to mapping method

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
