### PR TITLE
VP-2440: Fix CatalogImage.itemId empty field after import products

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
@@ -343,15 +343,16 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
                 Vendor = product.Vendor;
             }
 
-            var imgComparer = AnonymousComparer.Create((Image x) => x.Url);
-            Images = Images.Concat(product.Images).Distinct(imgComparer).ToList();
-
-            foreach (var image in Images)
+            foreach (var image in product.Images)
             {
-                var existedImage = product.Images.FirstOrDefault(x => imgComparer.Equals(x, image));
+                var existedImage = Images.FirstOrDefault(x => x.Url.Equals(image.Url, StringComparison.InvariantCultureIgnoreCase));
                 if (existedImage != null)
                 {
-                    image.Id = existedImage.Id;
+                    existedImage.Id = image.Id;
+                }
+                else
+                {
+                    Images.Add(image);
                 }
             }
 

--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
@@ -346,6 +346,15 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
             var imgComparer = AnonymousComparer.Create((Image x) => x.Url);
             Images = Images.Concat(product.Images).Distinct(imgComparer).ToList();
 
+            foreach (var image in Images)
+            {
+                var existedImage = product.Images.FirstOrDefault(x => imgComparer.Equals(x, image));
+                if (existedImage != null)
+                {
+                    image.Id = existedImage.Id;
+                }
+            }
+
             var assetComparer = AnonymousComparer.Create((Asset x) => x.Url);
             Assets = Assets.Concat(product.Assets).Distinct(assetComparer).ToList();
 

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/MergingTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/MergingTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using VirtoCommerce.CatalogCsvImportModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CoreModule.Core.Seo;
+using Xunit;
+
+namespace VirtoCommerce.CatalogCsvImportModule.Test
+{
+    public class MergingTests
+    {
+        [Fact]
+        public void CsvProductMergeTest_ProductHasSameImages_ImagesUpdated()
+        {
+            //Arrange
+            var catalogProduct = GetCatalogProductWithImage();
+            var csvProduct = new CsvProduct()
+            {
+                Images = new List<Image>() {new Image() {Id = "", Url = "SameURL"}}
+            };
+            //Act
+            csvProduct.MergeFrom(catalogProduct);
+
+            //Assets
+            Assert.Equal(1, csvProduct.Images.Count);
+            Assert.NotNull(csvProduct.Images.FirstOrDefault(x => x.Id == "1"));
+        }
+
+        [Fact]
+        public void CsvProductMergeTest_ProductHasAnotherImages_ImagesAdded()
+        {
+            //Arrange
+            var catalogProduct = GetCatalogProductWithImage();
+
+            var csvProduct = new CsvProduct()
+            {
+                Images = new List<Image>() { new Image() { Id = "", Url = "AnotherUrl" } }
+            };
+
+            //Act
+            csvProduct.MergeFrom(catalogProduct);
+
+            //Assert
+            Assert.Equal(2, csvProduct.Images.Count);
+            Assert.NotNull(csvProduct.Images.FirstOrDefault(x => x.Id == "1"));
+            Assert.NotNull(csvProduct.Images.FirstOrDefault(x => x.Id == ""));
+        }
+
+        private CatalogProduct GetCatalogProductWithImage()
+        {
+            return new CatalogProduct()
+            {
+                Images = new List<Image>() { new Image() { Id = "1", Url = "SameURL" } },
+                Assets = new List<Asset>(),
+                Reviews = new List<EditorialReview>(),
+                Properties = new List<Property>(),
+                SeoInfos = new List<SeoInfo>()
+            };
+        }
+
+    }
+}


### PR DESCRIPTION
### Problem
After CSV import already exist products with images rows that created in the table CatalogImage have empty field ItemId. 
![image](https://user-images.githubusercontent.com/11813599/91550414-2dd7ad00-e931-11ea-84db-23a9a065d691.png)

### Solution
Fill id field if image already exist

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
