### PR TITLE
VP-5463: Fix bugs with prices import

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
@@ -343,6 +343,51 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
                 Vendor = product.Vendor;
             }
 
+            if (string.IsNullOrWhiteSpace(Gtin))
+            {
+                Gtin = product.Gtin;
+            }
+
+            if (string.IsNullOrWhiteSpace(OuterId))
+            {
+                OuterId = product.OuterId;
+            }
+
+            if (string.IsNullOrWhiteSpace(PackageType))
+            {
+                PackageType = product.OuterId;
+            }
+
+            if (string.IsNullOrWhiteSpace(ManufacturerPartNumber))
+            {
+                ManufacturerPartNumber = product.ManufacturerPartNumber;
+            }
+
+            if (string.IsNullOrWhiteSpace(WeightUnit))
+            {
+                WeightUnit = product.WeightUnit;
+            }
+
+            if (string.IsNullOrWhiteSpace(MeasureUnit))
+            {
+                MeasureUnit = product.MeasureUnit;
+            }
+
+            if (string.IsNullOrWhiteSpace(DownloadType))
+            {
+                DownloadType = product.DownloadType;
+            }
+
+            if (string.IsNullOrWhiteSpace(ShippingType))
+            {
+                ShippingType = product.ShippingType;
+            }
+
+            if (string.IsNullOrWhiteSpace(TaxType))
+            {
+                TaxType = product.TaxType;
+            }
+
             foreach (var image in product.Images)
             {
                 var existedImage = Images.FirstOrDefault(x => x.Url.Equals(image.Url, StringComparison.InvariantCultureIgnoreCase));

--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
@@ -343,50 +343,58 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
                 Vendor = product.Vendor;
             }
 
-            if (string.IsNullOrWhiteSpace(Gtin))
+            if (string.IsNullOrEmpty(Gtin))
             {
                 Gtin = product.Gtin;
             }
 
-            if (string.IsNullOrWhiteSpace(OuterId))
+            if (string.IsNullOrEmpty(OuterId))
             {
                 OuterId = product.OuterId;
             }
 
-            if (string.IsNullOrWhiteSpace(PackageType))
+            if (string.IsNullOrEmpty(PackageType))
             {
-                PackageType = product.OuterId;
+                PackageType = product.PackageType;
             }
 
-            if (string.IsNullOrWhiteSpace(ManufacturerPartNumber))
+            if (string.IsNullOrEmpty(ManufacturerPartNumber))
             {
                 ManufacturerPartNumber = product.ManufacturerPartNumber;
             }
 
-            if (string.IsNullOrWhiteSpace(WeightUnit))
+            if (string.IsNullOrEmpty(WeightUnit))
             {
                 WeightUnit = product.WeightUnit;
             }
 
-            if (string.IsNullOrWhiteSpace(MeasureUnit))
+            if (string.IsNullOrEmpty(MeasureUnit))
             {
                 MeasureUnit = product.MeasureUnit;
             }
 
-            if (string.IsNullOrWhiteSpace(DownloadType))
+            if (string.IsNullOrEmpty(DownloadType))
             {
                 DownloadType = product.DownloadType;
             }
 
-            if (string.IsNullOrWhiteSpace(ShippingType))
+            if (string.IsNullOrEmpty(ShippingType))
             {
                 ShippingType = product.ShippingType;
             }
 
-            if (string.IsNullOrWhiteSpace(TaxType))
+            if (string.IsNullOrEmpty(TaxType))
             {
                 TaxType = product.TaxType;
             }
+
+            Weight ??= product.Weight;
+            Height ??= product.Height;
+            Length ??= product.Length;
+            Width ??= product.Width;
+
+            MaxQuantity ??= product.MaxQuantity;
+            MinQuantity ??= product.MinQuantity;
 
             foreach (var image in product.Images)
             {

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
@@ -313,7 +313,7 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
                     .Select(propertyGroup => GetMergedProperty(propertyGroup))
                     .ToList();
 
-                csvProduct.Prices = csvProduct.Prices.Where(x => x.EffectiveValue > 0).GroupBy(x => x.Currency).Select(g => g.FirstOrDefault()).ToList();
+                csvProduct.Prices = csvProduct.Prices.Where(x => x.EffectiveValue > 0).GroupBy(x => new { x.Currency , x.PricelistId} ).Select(g => g.FirstOrDefault()).ToList();
             }
         }
 


### PR DESCRIPTION
### Problem
1. GTIN is erasing after the Price csv import (need to check other fields also - e.g. OuterId)
2. Add another row with another PricelistId (existing for this catalog) and ListPrice. Only one price will be imported.

### Solution
Add groupBy parameter for prices selection.
Fill fields skipped in import.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
