### PR TITLE
VP-5516: Fix error when try to import product with German symbols in Dictionary

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvProductMap.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvProductMap.cs
@@ -67,15 +67,9 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
                     csvPropertyMap.UsingExpression<ICollection<Property>>(null, properties =>
                          {
                              var property = properties.FirstOrDefault(x => x.Name == propertyCsvColumn && x.Values.Any());
+                             var propertyValue = property?.Values.FirstOrDefault(x => x.Value != null || x.Alias != null);
 
-                             if (property != null)
-                             {
-                                 var propertyValues = property.Values.Where(x => x.Value != null || x.Alias != null).Select(x => x.Alias ?? x.Value.ToString());
-                                 var result = string.Join(mappingCfg.Delimiter, propertyValues);
-                                 return result;
-                             }
-
-                             return string.Empty;
+                             return propertyValue?.Alias ?? propertyValue?.Value.ToString() ?? string.Empty;
                          });
 
                     MemberMaps.Add(csvPropertyMap);


### PR DESCRIPTION
### Problem
VP-5516 Import products > error when try to import product with German symbols in Dictionary

### Solution
Fix export property values.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
