### PR TITLE
VP-5678: Product import more than 4 Descriptions are removed

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
@@ -424,7 +424,7 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
             var assetComparer = AnonymousComparer.Create((Asset x) => x.Url);
             Assets = Assets.Concat(product.Assets).Distinct(assetComparer).ToList();
 
-            var reviewsComparer = AnonymousComparer.Create((EditorialReview x) => string.Join(":", x.ReviewType, x.LanguageCode));
+            var reviewsComparer = AnonymousComparer.Create((EditorialReview x) => string.Join(":", x.ReviewType, x.LanguageCode, x.Content));
             Reviews = Reviews.Concat(product.Reviews).Distinct(reviewsComparer).ToList();
 
             // Merge Properties - leave properties that are not presented in CSV and add all from the CSV (with merging metadata and replacing existing ones)


### PR DESCRIPTION
### Problem
VP-5678 After Product import some descriptions are removed

### Solution
Add constraint.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
