### PR TITLE
VP-6117: Add product properties to csv export

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
@@ -353,11 +353,6 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
                 OuterId = product.OuterId;
             }
 
-            if (string.IsNullOrEmpty(OuterId))
-            {
-                OuterId = product.OuterId;
-            }
-
             if (string.IsNullOrEmpty(PackageType))
             {
                 PackageType = product.PackageType;

--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProductMappingConfiguration.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProductMappingConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -25,9 +25,10 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
             var optionalFields = ReflectionUtility.GetPropertyNames<CsvProduct>(x => x.Name, x => x.Id, x => x.Sku, x => x.CategoryPath, x => x.CategoryId, x => x.MainProductId, x => x.PrimaryImage, x => x.AltImage, x => x.SeoUrl, x => x.SeoTitle,
                                                                                 x => x.SeoDescription, x => x.SeoLanguage, x => x.SeoStore, x => x.Review, x => x.ReviewType, x => x.IsActive, x => x.IsBuyable, x => x.TrackInventory,
                                                                                 x => x.PriceId, x => x.SalePrice, x => x.ListPrice, x=>x.PriceMinQuantity, x => x.Currency, x => x.PriceListId, x => x.Quantity,
+                                                                                x => x.FulfillmentCenterId, x => x.PackageType, x=> x.OuterId, x=>x.Priority, x=>x.MaxQuantity, x=>x.MinQuantity, x=>x.ParentSku,
                                                                                 x => x.ManufacturerPartNumber, x => x.Gtin, x => x.MeasureUnit, x => x.WeightUnit, x => x.Weight,
                                                                                 x => x.Height, x => x.Length, x => x.Width, x => x.TaxType, x => x.ProductType, x => x.ShippingType,
-                                                                                x => x.Vendor, x => x.DownloadType, x => x.DownloadExpiration, x => x.HasUserAgreement);
+                                                                                x => x.Vendor, x => x.DownloadType, x => x.DownloadExpiration, x => x.HasUserAgreement , x=>x.MaxNumberOfDownload);
 
             retVal.PropertyMaps = requiredFields.Select(x => new CsvProductPropertyMap { EntityColumnName = x, CsvColumnName = x, IsRequired = true }).ToList();
             retVal.PropertyMaps.AddRange(optionalFields.Select(x => new CsvProductPropertyMap { EntityColumnName = x, CsvColumnName = x, IsRequired = false }));

--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProductMappingConfiguration.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProductMappingConfiguration.cs
@@ -25,7 +25,7 @@ namespace VirtoCommerce.CatalogCsvImportModule.Core.Model
             var optionalFields = ReflectionUtility.GetPropertyNames<CsvProduct>(x => x.Name, x => x.Id, x => x.Sku, x => x.CategoryPath, x => x.CategoryId, x => x.MainProductId, x => x.PrimaryImage, x => x.AltImage, x => x.SeoUrl, x => x.SeoTitle,
                                                                                 x => x.SeoDescription, x => x.SeoLanguage, x => x.SeoStore, x => x.Review, x => x.ReviewType, x => x.IsActive, x => x.IsBuyable, x => x.TrackInventory,
                                                                                 x => x.PriceId, x => x.SalePrice, x => x.ListPrice, x=>x.PriceMinQuantity, x => x.Currency, x => x.PriceListId, x => x.Quantity,
-                                                                                x => x.FulfillmentCenterId, x => x.PackageType, x=> x.OuterId, x=>x.Priority, x=>x.MaxQuantity, x=>x.MinQuantity, x=>x.ParentSku,
+                                                                                x => x.FulfillmentCenterId, x => x.PackageType, x=> x.OuterId, x=>x.Priority, x=>x.MaxQuantity, x=>x.MinQuantity,
                                                                                 x => x.ManufacturerPartNumber, x => x.Gtin, x => x.MeasureUnit, x => x.WeightUnit, x => x.Weight,
                                                                                 x => x.Height, x => x.Length, x => x.Width, x => x.TaxType, x => x.ProductType, x => x.ShippingType,
                                                                                 x => x.Vendor, x => x.DownloadType, x => x.DownloadExpiration, x => x.HasUserAgreement , x=>x.MaxNumberOfDownload);

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
@@ -156,10 +156,14 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
         private void ReplaceEmptyStringsWithNull(CsvProduct csvProduct)
         {
             csvProduct.Id = string.IsNullOrEmpty(csvProduct.Id) ? null : csvProduct.Id;
+            csvProduct.OuterId = string.IsNullOrEmpty(csvProduct.OuterId) ? null : csvProduct.OuterId;
             csvProduct.CategoryId = string.IsNullOrEmpty(csvProduct.CategoryId) ? null : csvProduct.CategoryId;
             csvProduct.MainProductId = string.IsNullOrEmpty(csvProduct.MainProductId) ? null : csvProduct.MainProductId;
             csvProduct.PriceId = string.IsNullOrEmpty(csvProduct.PriceId) ? null : csvProduct.PriceId;
             csvProduct.PriceListId = string.IsNullOrEmpty(csvProduct.PriceListId) ? null : csvProduct.PriceListId;
+            csvProduct.FulfillmentCenterId = string.IsNullOrEmpty(csvProduct.FulfillmentCenterId) ? null : csvProduct.FulfillmentCenterId;
+            csvProduct.PackageType = string.IsNullOrEmpty(csvProduct.PackageType) ? null : csvProduct.PackageType;
+            csvProduct.ParentSku = string.IsNullOrEmpty(csvProduct.ParentSku) ? null : csvProduct.ParentSku;
             csvProduct.Reviews = csvProduct.Reviews.Where(x => !string.IsNullOrEmpty(x.Content) && !string.IsNullOrEmpty(x.ReviewType)).ToList();
         }
 

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
@@ -163,7 +163,6 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
             csvProduct.PriceListId = string.IsNullOrEmpty(csvProduct.PriceListId) ? null : csvProduct.PriceListId;
             csvProduct.FulfillmentCenterId = string.IsNullOrEmpty(csvProduct.FulfillmentCenterId) ? null : csvProduct.FulfillmentCenterId;
             csvProduct.PackageType = string.IsNullOrEmpty(csvProduct.PackageType) ? null : csvProduct.PackageType;
-            csvProduct.ParentSku = string.IsNullOrEmpty(csvProduct.ParentSku) ? null : csvProduct.ParentSku;
             csvProduct.Reviews = csvProduct.Reviews.Where(x => !string.IsNullOrEmpty(x.Content) && !string.IsNullOrEmpty(x.ReviewType)).ToList();
         }
 

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/ImporterTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/ImporterTests.cs
@@ -27,7 +27,7 @@ using VirtoCommerce.StoreModule.Core.Model.Search;
 using VirtoCommerce.StoreModule.Core.Services;
 using Xunit;
 
-namespace VirtoCommerce.CatalogCsvImportModule.Test
+namespace VirtoCommerce.CatalogCsvImportModule.Tests
 {
     public class ImporterTests
     {

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/MappingTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/MappingTests.cs
@@ -60,6 +60,9 @@ namespace VirtoCommerce.CatalogCsvImportModule.Tests
             Assert.Equal("ShippingType_value", product.ShippingType);
             Assert.Equal("DownloadType_value", product.DownloadType);
             Assert.Equal("OuterId", product.OuterId);
+            Assert.Equal(1, product.Priority);
+            Assert.Equal(10, product.MaxQuantity);
+            Assert.Equal(5, product.MinQuantity);
             Assert.Equal("PackageType", product.PackageType);
             Assert.Equal("FulfillmentCenterId", product.FulfillmentCenterId);
             Assert.Equal(1, product.MaxNumberOfDownload);

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/MappingTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/MappingTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -13,7 +12,7 @@ using VirtoCommerce.CatalogCsvImportModule.Data.Services;
 using VirtoCommerce.CatalogModule.Core.Model;
 using Xunit;
 
-namespace VirtoCommerce.CatalogCsvImportModule.Test
+namespace VirtoCommerce.CatalogCsvImportModule.Tests
 {
     public class MappingTests
     {
@@ -60,6 +59,11 @@ namespace VirtoCommerce.CatalogCsvImportModule.Test
             Assert.Equal("ProductType_value", product.ProductType);
             Assert.Equal("ShippingType_value", product.ShippingType);
             Assert.Equal("DownloadType_value", product.DownloadType);
+            Assert.Equal("OuterId", product.OuterId);
+            Assert.Equal("PackageType", product.PackageType);
+            Assert.Equal("FulfillmentCenterId", product.FulfillmentCenterId);
+            Assert.Equal(1, product.MaxNumberOfDownload);
+
             Assert.True(product.HasUserAgreement);
             Assert.True(product.IsBuyable);
             Assert.True(product.TrackInventory);

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/MergingTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/MergingTests.cs
@@ -5,7 +5,7 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CoreModule.Core.Seo;
 using Xunit;
 
-namespace VirtoCommerce.CatalogCsvImportModule.Test
+namespace VirtoCommerce.CatalogCsvImportModule.Tests
 {
     public class MergingTests
     {

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/TestUtils.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/TestUtils.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using Newtonsoft.Json;
 using VirtoCommerce.Platform.Core.Common;
 
-namespace VirtoCommerce.CatalogCsvImportModule.Test
+namespace VirtoCommerce.CatalogCsvImportModule.Tests
 {
     public static class TestUtils
     {

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/data/product-productproperties.csv
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/data/product-productproperties.csv
@@ -1,2 +1,2 @@
-Name,Id,Sku,CategoryId,Gtin,MainProductId,PrimaryImage,ProductType,ShippingType,Vendor,DownloadType,HasUserAgreement,IsBuyable,TrackInventory
-cblk21113-product-1,429408,CBLK21113,catId_1,GTIN_Value,mainprod_123,"http://localhost/image.jpg",ProductType_value,ShippingType_value,Vendor_value,DownloadType_value,true,true,true
+Name,Id,Sku,CategoryId,Gtin,MainProductId,PrimaryImage,ProductType,ShippingType,Vendor,DownloadType,HasUserAgreement,IsBuyable,TrackInventory,OuterId,PackageType,FulfillmentCenterId,MaxNumberOfDownload
+cblk21113-product-1,429408,CBLK21113,catId_1,GTIN_Value,mainprod_123,http://localhost/image.jpg,ProductType_value,ShippingType_value,Vendor_value,DownloadType_value,TRUE,TRUE,TRUE,OuterId,PackageType,FulfillmentCenterId,1

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/data/product-productproperties.csv
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/data/product-productproperties.csv
@@ -1,2 +1,2 @@
-Name,Id,Sku,CategoryId,Gtin,MainProductId,PrimaryImage,ProductType,ShippingType,Vendor,DownloadType,HasUserAgreement,IsBuyable,TrackInventory,OuterId,PackageType,FulfillmentCenterId,MaxNumberOfDownload
-cblk21113-product-1,429408,CBLK21113,catId_1,GTIN_Value,mainprod_123,http://localhost/image.jpg,ProductType_value,ShippingType_value,Vendor_value,DownloadType_value,TRUE,TRUE,TRUE,OuterId,PackageType,FulfillmentCenterId,1
+Name,Id,Sku,CategoryId,Gtin,MainProductId,PrimaryImage,ProductType,ShippingType,Vendor,DownloadType,HasUserAgreement,IsBuyable,TrackInventory,OuterId,PackageType,FulfillmentCenterId,MaxNumberOfDownload,Priority,MaxQuantity,MinQuantity
+cblk21113-product-1,429408,CBLK21113,catId_1,GTIN_Value,mainprod_123,http://localhost/image.jpg,ProductType_value,ShippingType_value,Vendor_value,DownloadType_value,TRUE,TRUE,TRUE,OuterId,PackageType,FulfillmentCenterId,1,1,10,5


### PR DESCRIPTION
### Related task:     
   VP-6117 Some fields are not presented in the import mappings
### Problem
   Some of the CsvProduct properties are missing: e.g. PackageType, FulfillmentCenterId
### Solution:
      Add missed some product fields to export

