### PR TITLE
PT-4135: Use assets from newly created module instead of the platform

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Model/CsvProduct.cs
@@ -6,7 +6,7 @@ using Omu.ValueInjecter;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CoreModule.Core.Seo;
 using VirtoCommerce.InventoryModule.Core.Model;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.PricingModule.Core.Model;
 

--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/VirtoCommerce.CatalogCsvImportModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/VirtoCommerce.CatalogCsvImportModule.Core.csproj
@@ -15,6 +15,6 @@
         <PackageReference Include="VirtoCommerce.ExportModule.Core" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1.0" />
-        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
     </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/VirtoCommerce.CatalogCsvImportModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/VirtoCommerce.CatalogCsvImportModule.Core.csproj
@@ -15,5 +15,6 @@
         <PackageReference Include="VirtoCommerce.ExportModule.Core" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1.0" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
     </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogExporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogExporter.cs
@@ -18,7 +18,7 @@ using VirtoCommerce.CoreModule.Core.Seo;
 using VirtoCommerce.InventoryModule.Core.Model;
 using VirtoCommerce.InventoryModule.Core.Model.Search;
 using VirtoCommerce.InventoryModule.Core.Services;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.ExportImport;
 using VirtoCommerce.PricingModule.Core.Model;

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/VirtoCommerce.CatalogCsvImportModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/VirtoCommerce.CatalogCsvImportModule.Data.csproj
@@ -18,8 +18,9 @@
         <PackageReference Include="Ude.NetStandard" Version="1.2.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.2.0" />
-        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.0.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1.0" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/VirtoCommerce.CatalogCsvImportModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/VirtoCommerce.CatalogCsvImportModule.Data.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.2.0" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1.0" />
-        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/Controllers/Api/CatalogModuleExportImportController.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/Controllers/Api/CatalogModuleExportImportController.cs
@@ -19,7 +19,7 @@ using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.CatalogModule.Data.Authorization;
 using VirtoCommerce.CoreModule.Core.Currency;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Exceptions;
 using VirtoCommerce.Platform.Core.ExportImport;

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/Scripts/blades/import/wizard/catalog-CSV-import-wizard.js
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/Scripts/blades/import/wizard/catalog-CSV-import-wizard.js
@@ -20,7 +20,7 @@ angular.module('virtoCommerce.catalogCsvImportModule')
             var uploader = $scope.uploader = new FileUploader({
                 scope: $scope,
                 headers: { Accept: 'application/json' },
-                url: 'api/platform/assets?folderUrl=tmp',
+                url: 'api/assets?folderUrl=tmp',
                 method: 'POST',
                 autoUpload: true,
                 removeAfterUpload: true

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/VirtoCommerce.CatalogCsvImportModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/VirtoCommerce.CatalogCsvImportModule.Web.csproj
@@ -22,12 +22,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.1.1" />
-    <PackageReference Include="FluentValidation" Version="8.6.2" />
+    <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="Hangfire" Version="1.7.9" />
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.2.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.0.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.0.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.81.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.81.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/VirtoCommerce.CatalogCsvImportModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/VirtoCommerce.CatalogCsvImportModule.Web.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.81.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.81.0" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.CatalogCsvImportModule</id>
   <version>3.28.0</version>
   <version-tag />
-  <platformVersion>3.0.0</platformVersion>
+  <platformVersion>3.81.0</platformVersion>
   <title>Csv Catalog Import Module</title>
   <description>Adds CSV import functionality to catalog</description>
   <authors>
@@ -23,6 +23,7 @@
     <dependency id="VirtoCommerce.Inventory" version="3.0.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.0.0" />
     <dependency id="VirtoCommerce.Store" version="3.0.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.0.0" />
   </dependencies>
   <groups>
     <group>commerce</group>

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/module.manifest
@@ -23,7 +23,7 @@
     <dependency id="VirtoCommerce.Inventory" version="3.0.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.0.0" />
     <dependency id="VirtoCommerce.Store" version="3.0.0" />
-    <dependency id="VirtoCommerce.Assets" version="3.0.0" />
+    <dependency id="VirtoCommerce.Assets" version="1.0.0" />
   </dependencies>
   <groups>
     <group>commerce</group>

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/VirtoCommerce.CatalogCsvImportModule.Tests.csproj
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/VirtoCommerce.CatalogCsvImportModule.Tests.csproj
@@ -30,8 +30,9 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/VirtoCommerce.CatalogCsvImportModule.Tests.csproj
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/VirtoCommerce.CatalogCsvImportModule.Tests.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1.0" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />


### PR DESCRIPTION
## Description
Use assets from newly created module instead of the platform
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4135
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogCsvImportModule_3.29.0-pr-87.zip
