### PR TITLE
PT-4758: Import with 'Csv column delimiter' = Comma: delimiter issue

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
@@ -718,6 +718,15 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
 
                             property.Values = parsedValues;
                         }
+                        // Combining multiple values ​​into one for non-multivalued properties
+                        else if (property.Values.Count > 1)
+                        {
+                            var propertyValues = new List<PropertyValue>();
+                            var propertyValue = property.Values.FirstOrDefault();
+                            propertyValue.Value = string.Join(CsvReaderExtension.Delimiter, property.Values.Select(x => x.Value));
+                            propertyValues.Add(propertyValue);
+                            property.Values = propertyValues;
+                        }
                     }
                 }
             }

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
@@ -411,11 +411,11 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
                 outline.Clear();
                 var productCategoryNames = csvProduct.Category.Path.Split(_categoryDelimiters);
                 string parentCategoryId = null;
+                var count = progressInfo.ProcessedCount;
                 foreach (var categoryName in productCategoryNames)
                 {
                     outline.Append($"\\{categoryName}");
-                    Category category;
-                    if (!cachedCategoryMap.TryGetValue(outline.ToString(), out category))
+                    if (!cachedCategoryMap.TryGetValue(outline.ToString(), out var category))
                     {
                         var searchCriteria = new CategorySearchCriteria
                         {
@@ -424,31 +424,43 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
                             SearchOnlyInRoot = parentCategoryId == null,
                             Keyword = categoryName
                         };
+
                         category = (await _categorySearchService.SearchCategoriesAsync(searchCriteria)).Results.FirstOrDefault();
                     }
 
                     if (category == null)
                     {
-                        var code = categoryName.GenerateSlug();
-                        if (string.IsNullOrEmpty(code))
+                        category = new Category
                         {
-                            code = Guid.NewGuid().ToString("N");
-                        }
+                            Name = categoryName,
+                            Code = GenerateSlug(categoryName),
+                            CatalogId = catalog.Id,
+                            ParentId = parentCategoryId
+                        };
 
-                        category = new Category() { Name = categoryName, Code = code, CatalogId = catalog.Id, ParentId = parentCategoryId };
                         await _categoryService.SaveChangesAsync(new[] { category });
 
                         //Raise notification each notifyCategorySizeLimit category
-                        var count = progressInfo.ProcessedCount;
                         progressInfo.Description = $"Creating categories: {++count} created";
                         progressCallback(progressInfo);
                     }
+
                     csvProduct.CategoryId = category.Id;
                     csvProduct.Category = category;
                     parentCategoryId = category.Id;
                     cachedCategoryMap[outline.ToString()] = category;
                 }
             }
+        }
+
+        private string GenerateSlug(string categoryName)
+        {
+            var code = categoryName.GenerateSlug();
+            if (string.IsNullOrEmpty(code))
+            {
+                code = Guid.NewGuid().ToString("N");
+            }
+            return code;
         }
 
         private async Task SaveProducts(List<CsvProduct> csvProducts, ExportImportProgressInfo progressInfo, Action<ExportImportProgressInfo> progressCallback)

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
@@ -721,11 +721,9 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
                         // Combining multiple values ​​into one for non-multivalued properties
                         else if (property.Values.Count > 1)
                         {
-                            var propertyValues = new List<PropertyValue>();
                             var propertyValue = property.Values.FirstOrDefault();
                             propertyValue.Value = string.Join(CsvReaderExtension.Delimiter, property.Values.Select(x => x.Value));
-                            propertyValues.Add(propertyValue);
-                            property.Values = propertyValues;
+                            property.Values = new List<PropertyValue> { propertyValue };
                         }
                     }
                 }


### PR DESCRIPTION
## Description
If multivalue:
![изображение](https://user-images.githubusercontent.com/88537215/140869707-acaa5d08-0e22-41c9-9004-629aa4969260.png)

If not multivalue:
![изображение](https://user-images.githubusercontent.com/88537215/140869587-73cc6ce6-73fb-46ea-a2e0-3264a66f2156.png)
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4758
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogCsvImportModule_3.28.0-pr-88.zip
