### PR TITLE
Fix filtered map for bool fields

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvProductMap.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvProductMap.cs
@@ -27,8 +27,8 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
 
                     newMap.Data.TypeConverterOptions.CultureInfo = CultureInfo.InvariantCulture;
                     newMap.Data.TypeConverterOptions.NumberStyles = NumberStyles.Any;
-                    newMap.Data.TypeConverterOptions.BooleanTrueValues.AddRange(new List<string>() { "yes", "true" });
-                    newMap.Data.TypeConverterOptions.BooleanFalseValues.AddRange(new List<string>() { "false", "no" });
+                    newMap.Data.TypeConverterOptions.BooleanTrueValues.AddRange(new List<string>() { "True", "Yes" });
+                    newMap.Data.TypeConverterOptions.BooleanFalseValues.AddRange(new List<string>() { "False", "No" });
 
                     newMap.Data.Index = ++index;
 


### PR DESCRIPTION
## Description
The correction is necessary so that when importing files, values with the "bool" type are correctly replaced. To get the correct match and eliminate errors when using parsing in bool values

This correction was made in the Export module, leading to a general view of the bool value parsing settings, this correction must be applied to this module as well.
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogCsvImportModule_3.801.0-pr-108-b609.zip
