### PR TITLE
VCST-5163: Stable 15 — CatalogCsvImportModule (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/VirtoCommerce.CatalogCsvImportModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/VirtoCommerce.CatalogCsvImportModule.Core.csproj
@@ -14,10 +14,10 @@
   <ItemGroup>
     
     <PackageReference Include="ValueInjecter" Version="3.2.0" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
+    <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/VirtoCommerce.CatalogCsvImportModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/VirtoCommerce.CatalogCsvImportModule.Data.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     
-    <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.1029.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />
@@ -27,7 +27,7 @@
 
   <!--Workaround for vulnerable transitive packages-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/VirtoCommerce.CatalogCsvImportModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/VirtoCommerce.CatalogCsvImportModule.Web.csproj
@@ -21,8 +21,8 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/module.manifest
@@ -4,14 +4,14 @@
   <version>3.1002.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Pricing" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Inventory" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Pricing" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <title>CSV Catalog Export and Import Module</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 6). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–5 packages on nuget.org. Version handled by CI.

- NU1605 Microsoft.Extensions.Caching.Memory bump.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and manifest version bumps only; behavior changes would come from upstream Virto packages, not from new logic in this repo.
> 
> **Overview**
> **Stable 15 / Wave 6** alignment: bumps Virto Commerce **NuGet** references and **`module.manifest`** so Catalog CSV Import targets **platform `3.1039.0`** and matching module dependency versions (Assets, Catalog, Core, Inventory, Pricing, Store, Hangfire).
> 
> In **Data**, **`Microsoft.Extensions.Caching.Memory`** is raised from **`10.0.3`** to **`10.0.9`** to resolve **NU1605** / transitive package constraints. No application source changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 904c914689188da2b874d537ad0386884b4d8667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogCsvImportModule_3.1002.0-pr-138-904c.zip