### PR TITLE
VCST-5661: Null-guard MapTo and move ICatalogCsvImportModuleMapper to Core

### DIFF
--- a/samples/VirtoCommerce.CatalogCsvImportModuleSample/Data/ExCsvProductConverter.cs
+++ b/samples/VirtoCommerce.CatalogCsvImportModuleSample/Data/ExCsvProductConverter.cs
@@ -1,4 +1,5 @@
 using VirtoCommerce.CatalogCsvImportModule.Core.Model;
+using VirtoCommerce.CatalogCsvImportModule.Core.Services;
 using VirtoCommerce.CatalogCsvImportModule.Data.Services;
 using VirtoCommerce.CatalogCsvImportModuleSample.Core;
 using VirtoCommerce.CatalogModule.Core.Model;

--- a/samples/VirtoCommerce.CatalogCsvImportModuleSample/Data/ExDataAssemblyMarker.cs
+++ b/samples/VirtoCommerce.CatalogCsvImportModuleSample/Data/ExDataAssemblyMarker.cs
@@ -1,3 +1,0 @@
-namespace VirtoCommerce.CatalogCsvImportModuleSample.Data;
-
-public class ExDataAssemblyMarker;

--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/Services/ICatalogCsvImportModuleMapper.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/Services/ICatalogCsvImportModuleMapper.cs
@@ -1,7 +1,7 @@
 using VirtoCommerce.CatalogCsvImportModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model;
 
-namespace VirtoCommerce.CatalogCsvImportModule.Data.Services;
+namespace VirtoCommerce.CatalogCsvImportModule.Core.Services;
 
 public interface ICatalogCsvImportModuleMapper
 {

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/DataAssemblyMarker.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/DataAssemblyMarker.cs
@@ -1,3 +1,0 @@
-namespace VirtoCommerce.CatalogCsvImportModule.Data;
-
-public class DataAssemblyMarker;

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CatalogCsvImportModuleMapper.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CatalogCsvImportModuleMapper.cs
@@ -1,4 +1,6 @@
+using System;
 using VirtoCommerce.CatalogCsvImportModule.Core.Model;
+using VirtoCommerce.CatalogCsvImportModule.Core.Services;
 using VirtoCommerce.CatalogModule.Core.Model;
 
 namespace VirtoCommerce.CatalogCsvImportModule.Data.Services;
@@ -7,6 +9,8 @@ public class CatalogCsvImportModuleMapper : ICatalogCsvImportModuleMapper
 {
     public virtual void MapTo(CsvProduct source, CatalogProduct target)
     {
+        ArgumentNullException.ThrowIfNull(target);
+
         if (source == null)
         {
             return;

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/CatalogCsvImportModuleMapperTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/CatalogCsvImportModuleMapperTests.cs
@@ -56,6 +56,14 @@ public class CatalogCsvImportModuleMapperTests
     }
 
     [Fact]
+    public void MapTo_NullTarget_Throws()
+    {
+        var source = new CsvProduct { Id = "id-1" };
+
+        FluentActions.Invoking(() => _mapper.MapTo(source, null)).Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
     public void MapTo_CopiesScalarAndReferenceFields()
     {
         var source = new CsvProduct

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/ModuleRegistrationTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/ModuleRegistrationTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.CatalogCsvImportModule.Core.Services;
 using VirtoCommerce.CatalogCsvImportModule.Data.Services;
 using VirtoCommerce.CatalogCsvImportModule.Web;
 using Xunit;


### PR DESCRIPTION
## Description
Two independent fixes carried into this branch:

1. Adds `ArgumentNullException.ThrowIfNull(target)` to `CatalogCsvImportModuleMapper.MapTo(CsvProduct, CatalogProduct)` — matches the null-guard convention (destination throws, source is a silent no-op) applied to every other `MapTo`-onto-interface method across this AutoMapper-replacement initiative (x-catalog, x-cart, x-order).
2. Moves `ICatalogCsvImportModuleMapper` from `VirtoCommerce.CatalogCsvImportModule.Data.Services` to `VirtoCommerce.CatalogCsvImportModule.Core.Services`, matching every sibling interface in this module (`ICsvCatalogExporter`, `ICsvCatalogImporter`, `ICsvProductConverter`, `ICsvProductReader`), all of which already live in `Core`. Removes the now-orphaned `DataAssemblyMarker`/`ExDataAssemblyMarker`, which existed only to anchor an assembly scan for the now-removed AutoMapper `AddAutoMapper` registration.

No schema change, no migrations, no new settings, no new dependencies.

## New GraphQL queries and mutations
None — this module has no GraphQL surface.

## Changes to existing GraphQL queries and mutations
None.

## New public services / interfaces / methods
None new — `ICatalogCsvImportModuleMapper`'s namespace changed (see Breaking changes); no member was added or removed.

## New protected methods (extensibility)
None new.

## Breaking changes
- Removed/moved published surface: `ICatalogCsvImportModuleMapper` moved from `VirtoCommerce.CatalogCsvImportModule.Data.Services` to `VirtoCommerce.CatalogCsvImportModule.Core.Services` — any external consumer with a `using` for the old namespace needs updating. No `[Obsolete]` forwarding type added — module is pre-release, no external callers outside this repo's own DI registration.
- Removed published surface: `DataAssemblyMarker` and the sample project's `ExDataAssemblyMarker` deleted — both had no reachable purpose once `AddAutoMapper`'s assembly scan was removed; this module's schema registration was never routed through either type.
- Behaviour change, no compile-time warning: `MapTo(CsvProduct, CatalogProduct)` now throws `ArgumentNullException` when `target` is null, instead of the prior unguarded property-copy that would NRE partway through. `source == null` remains a silent no-op.
- Security-ticket status: this repo's AutoMapper removal (VCST-5659, #142) is already merged; this PR only carries this wave's (VCST-5661) null-guard convention fix, already applied identically to x-catalog, x-cart, and x-order.

## New dependencies
None.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5661
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogCsvImportModule_3.1004.0-pr-146-f9d3.zip